### PR TITLE
Add `-ndk` to tagPrefix in push script

### DIFF
--- a/push.sh
+++ b/push.sh
@@ -2,7 +2,7 @@
 
 source defaults.sh
 
-for tagPrefix in "platform-only" "ndk-only" ${API_LEVELS[@]}
+for tagPrefix in "platform-only" "ndk-only" ${API_LEVELS[@]/%/-ndk} ${API_LEVELS[@]}
 do
   for tagSuffix in "latest" ${EXTRA_TAGS[@]}
   do


### PR DESCRIPTION
The ndk images were not pushed by the script. 